### PR TITLE
Resolver refactor alatham

### DIFF
--- a/code/api/src/modules/user/mutations.test.js
+++ b/code/api/src/modules/user/mutations.test.js
@@ -78,22 +78,22 @@ describe("user mutations", () => {
     expect(response2.body.data.userStyleSummaryUpdate.styleSummary).toEqual("prep, but comfy")
   })
 
-  // it ("can update a user's style summary if there is only one style selected [edge case]", async() => {
-  //   const data = {
-  //     query: `mutation {
-  //       userStyleSummaryUpdate(
-  //         id: 1,
-  //         styleSurvey: ["comfy", "comfy", "comfy", "comfy", "comfy"]
-  //       )
-  //       { styleSummary }
-  //     }`
-  //   }
-  //
-  //   var response = await request(server)
-  //     .post('/')
-  //     .send(data)
-  //     .expect(200)
-  //
-  //   expect(response.body.data.userStyleSummaryUpdate.styleSummary).toEqual("comfy")
-  // })
+  it ("can update a user's style summary if there is only one style selected [edge case]", async() => {
+    const data = {
+      query: `mutation {
+        userStyleSummaryUpdate(
+          id: 1,
+          styleSurvey: ["comfy", "comfy", "comfy", "comfy", "comfy"]
+        )
+        { styleSummary }
+      }`
+    }
+
+    var response = await request(server)
+      .post('/')
+      .send(data)
+      .expect(200)
+
+    expect(response.body.data.userStyleSummaryUpdate.styleSummary).toEqual("comfy")
+  })
 })


### PR DESCRIPTION
Refactors the user resolver for `updateStyleSummary` to:
* Handle an edge case where only one type of style is selected in the survey
* Utilize three helper methods: `tallyStyles`, `orderStyles`, and `generateStyleSummary`

Adds one more test for edge case (see first bullet).

Verify tests work by running `cd code/api && npm test` then tap `a` to run all API tests.